### PR TITLE
Specify a version for the 'feed' build dependency.

### DIFF
--- a/git-annex.cabal
+++ b/git-annex.cabal
@@ -222,7 +222,7 @@ Executable git-annex
     CPP-Options: -DWITH_DNS
 
   if flag(Feed)
-    Build-Depends: feed
+    Build-Depends: feed (>= 0.3.4)
     CPP-Options: -DWITH_FEED
   
   if flag(Quvi)


### PR DESCRIPTION
Versions of feed before 0.3.4 don't have 'getItemSummary', which is used
in ImportFeed.hs.

With this patch I can successfully build git-annex on my mac.