### PR TITLE
Enh standalone build

### DIFF
--- a/debian/create-standalone-changelog
+++ b/debian/create-standalone-changelog
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# A little helper script to build a package with standalone git-annex
+# It relies on being run within git-annex Git repository
+#
+set -eu
+
+umask 022
+
+git checkout debian/changelog
+
+ANNEX_VERSION=$(git describe HEAD)
+ANNEX_NDVERSION=$( echo ${ANNEX_VERSION} | sed -e 's,-,+git,' -e 's,$,-1~ndall+1,')
+
+dch --noconf -v ${ANNEX_NDVERSION} \
+    --force-bad-version --force-distribution -D neurodebian "Backported fresh snapshot"

--- a/debian/patches/series.standalone-build
+++ b/debian/patches/series.standalone-build
@@ -1,0 +1,1 @@
+standalone-build

--- a/debian/patches/standalone-build
+++ b/debian/patches/standalone-build
@@ -54,16 +54,10 @@ Last-Update: 2015-04-20
 +debian/git-annex-standalone/usr/lib/git-annex.linux/usr/share/man/man1/git-annex*
 --- a/debian/rules
 +++ b/debian/rules
-@@ -3,7 +3,17 @@
- export CABAL=debian/cabal-wrapper
+@@ -12,6 +12,15 @@ export RELEASE_BUILD=1
+ # Rules for providing a standalone build of annex.
+ #
  
- # Do use the changelog's version number, rather than making one up.
--export RELEASE_BUILD=1
-+export RELEASE_BUILD=0
- 
- %:
- 	dh $@
-+
 +override_dh_auto_build:
 +	make linuxstandalone
 +
@@ -73,3 +67,6 @@ Last-Update: 2015-04-20
 +override_dh_fixperms:
 +	dh_fixperms -Xld-linux
 +
+ build-standalone:
+ 	[ -e .git ]
+ 	git checkout debian/changelog

--- a/debian/patches/standalone-build
+++ b/debian/patches/standalone-build
@@ -1,0 +1,75 @@
+From: Yaroslav Halchenko <debian@onerussian.com>
+Subject: Patch debian/ to provide a standalone build of git-annex
+
+Origin: NeuroDebian
+Last-Update: 2015-04-20
+
+--- a/debian/control
++++ b/debian/control
+@@ -87,11 +87,13 @@ Vcs-Git: git://git.kitenet.net/git-annex
+ Homepage: http://git-annex.branchable.com/
+ XS-Testsuite: autopkgtest
+ 
+-Package: git-annex
++Package: git-annex-standalone
+ Architecture: any
+ Section: utils
+-Depends: ${misc:Depends}, ${shlibs:Depends},
+-	git (>= 1:1.8.1),
++Conflicts: git-annex
++Provides: git-annex
++Depends: ${misc:Depends},
++	git,
+ 	rsync,
+ 	wget,
+ 	curl,
+@@ -110,7 +112,7 @@ Suggests:
+ 	bup,
+ 	tahoe-lafs,
+ 	libnss-mdns,
+-Description: manage files with git, without checking their contents into git
++Description: manage files with git, without checking their contents into git -- standalone build
+  git-annex allows managing files with git, without checking the file
+  contents into git. While that may seem paradoxical, it is useful when
+  dealing with files larger than git can currently easily handle, whether due
+@@ -128,3 +130,7 @@ Description: manage files with git, with
+  noticing when files are changed, and automatically committing them
+  to git and transferring them to other computers. The git-annex webapp
+  makes it easy to set up and use git-annex this way.
++ .
++ This package provides a standalone bundle build of git-annex, which
++ should be installable on any more or less recent Debian or Ubuntu
++ release.
+--- /dev/null
++++ b/debian/install
+@@ -0,0 +1 @@
++tmp/git-annex.linux usr/lib
+--- /dev/null
++++ b/debian/links
+@@ -0,0 +1 @@
++/usr/lib/git-annex.linux/git-annex /usr/bin/git-annex
+--- /dev/null
++++ b/debian/manpages
+@@ -0,0 +1 @@
++debian/git-annex-standalone/usr/lib/git-annex.linux/usr/share/man/man1/git-annex*
+--- a/debian/rules
++++ b/debian/rules
+@@ -3,7 +3,17 @@
+ export CABAL=debian/cabal-wrapper
+ 
+ # Do use the changelog's version number, rather than making one up.
+-export RELEASE_BUILD=1
++export RELEASE_BUILD=0
+ 
+ %:
+ 	dh $@
++
++override_dh_auto_build:
++	make linuxstandalone
++
++override_dh_auto_install:
++	: # nothing to do, we just need to copy the beast, as instructed in debian/install
++
++override_dh_fixperms:
++	dh_fixperms -Xld-linux
++

--- a/debian/rules
+++ b/debian/rules
@@ -7,3 +7,16 @@ export RELEASE_BUILD=1
 
 %:
 	dh $@
+
+#
+# Rules for providing a standalone build of annex.
+#
+
+build-standalone:
+	[ -e .git ]
+	git checkout debian/changelog
+	quilt pop -a || :
+	QUILT_SERIES=series.standalone-build quilt push -a
+	debian/create-standalone-changelog
+	dpkg-buildpackage -rfakeroot
+	quilt pop -a


### PR DESCRIPTION
Something like that?  Probably

- should build just a source package (to be then deferred to whatever builder is supposed to build binaries)
- ATM refers to  neurodebian   as the suite and adds neurodebian specific ```~nd``` version suffix.  What would you advise to do instead?