### PR TITLE
Fix and improve standalone build

### DIFF
--- a/debian/create-standalone-changelog
+++ b/debian/create-standalone-changelog
@@ -13,5 +13,7 @@ ANNEX_VERSION=$(runghc Build/BuildVersion.hs)
 
 ANNEX_NDVERSION=$( echo ${ANNEX_VERSION} | sed -e 's,-,+git,' -e 's,$,-1~ndall+1,')
 
+echo "I: Building 'NeuroDebian' flavor version $ANNEX_NDVERSION for stock $ANNEX_VERSION"
+
 dch --noconf -v ${ANNEX_NDVERSION} \
     --force-bad-version --force-distribution -D neurodebian "Backported fresh snapshot"

--- a/debian/patches/standalone-build
+++ b/debian/patches/standalone-build
@@ -6,7 +6,7 @@ Last-Update: 2015-04-20
 
 --- a/debian/control
 +++ b/debian/control
-@@ -89,15 +89,14 @@ Vcs-Git: git://git.kitenet.net/git-annex
+@@ -87,15 +87,14 @@ Vcs-Git: git://git.kitenet.net/git-annex
  Homepage: http://git-annex.branchable.com/
  XS-Testsuite: autopkgtest
  
@@ -28,7 +28,7 @@ Last-Update: 2015-04-20
  Recommends: 
  	lsof,
  	gnupg,
-@@ -112,7 +111,7 @@ Suggests:
+@@ -110,7 +109,7 @@ Suggests:
  	bup,
  	tahoe-lafs,
  	libnss-mdns,
@@ -37,7 +37,7 @@ Last-Update: 2015-04-20
   git-annex allows managing files with git, without checking the file
   contents into git. While that may seem paradoxical, it is useful when
   dealing with files larger than git can currently easily handle, whether due
-@@ -130,3 +129,7 @@ Description: manage files with git, with
+@@ -128,3 +127,7 @@ Description: manage files with git, with
   noticing when files are changed, and automatically committing them
   to git and transferring them to other computers. The git-annex webapp
   makes it easy to set up and use git-annex this way.
@@ -57,21 +57,3 @@ Last-Update: 2015-04-20
 +++ b/debian/manpages
 @@ -0,0 +1 @@
 +debian/git-annex-standalone/usr/lib/git-annex.linux/usr/share/man/man1/git-annex*
---- a/debian/rules
-+++ b/debian/rules
-@@ -8,6 +8,15 @@ export RELEASE_BUILD=1
- %:
- 	dh $@
- 
-+override_dh_auto_build:
-+	make linuxstandalone
-+
-+override_dh_auto_install:
-+	: # nothing to do, we just need to copy the beast, as instructed in debian/install
-+
-+override_dh_fixperms:
-+	dh_fixperms -Xld-linux
-+
- # Run this target to build git-annex-standalone.deb
- build-standalone:
- 	test -e .git

--- a/debian/patches/standalone-build
+++ b/debian/patches/standalone-build
@@ -6,7 +6,7 @@ Last-Update: 2015-04-20
 
 --- a/debian/control
 +++ b/debian/control
-@@ -89,11 +89,13 @@ Vcs-Git: git://git.kitenet.net/git-annex
+@@ -89,15 +89,14 @@ Vcs-Git: git://git.kitenet.net/git-annex
  Homepage: http://git-annex.branchable.com/
  XS-Testsuite: autopkgtest
  
@@ -16,14 +16,19 @@ Last-Update: 2015-04-20
  Section: utils
 -Depends: ${misc:Depends}, ${shlibs:Depends},
 -	git (>= 1:1.8.1),
+-	rsync,
+-	wget,
+-	curl,
+-	openssh-client (>= 1:5.6p1)
 +Conflicts: git-annex
 +Provides: git-annex
 +Depends: ${misc:Depends},
 +	git,
- 	rsync,
- 	wget,
- 	curl,
-@@ -112,7 +114,7 @@ Suggests:
++	openssh-client
+ Recommends: 
+ 	lsof,
+ 	gnupg,
+@@ -112,7 +111,7 @@ Suggests:
  	bup,
  	tahoe-lafs,
  	libnss-mdns,
@@ -32,7 +37,7 @@ Last-Update: 2015-04-20
   git-annex allows managing files with git, without checking the file
   contents into git. While that may seem paradoxical, it is useful when
   dealing with files larger than git can currently easily handle, whether due
-@@ -130,3 +132,7 @@ Description: manage files with git, with
+@@ -130,3 +129,7 @@ Description: manage files with git, with
   noticing when files are changed, and automatically committing them
   to git and transferring them to other computers. The git-annex webapp
   makes it easy to set up and use git-annex this way.

--- a/debian/rules
+++ b/debian/rules
@@ -2,18 +2,50 @@
 
 export CABAL=debian/cabal-wrapper
 
+STANDALONE_BUILD=$(shell grep -qe '^Package: git-annex-standalone' debian/control \
+                         && echo 1 || echo 0)
+
+ifndef SNAPSHOT_BUILD
 # Do use the changelog's version number, rather than making one up.
 export RELEASE_BUILD=1
+endif
+
 
 %:
 	dh $@
 
-# Run this target to build git-annex-standalone.deb
-build-standalone:
+
+# Run this target to build git-annex-standalone*.deb
+build-standalone: dpkg-buildpackage-F
+# Run this target to build git-annex-standalone*.dsc
+build-standalone-dsc: dpkg-buildpackage-S
+
+
+# Standalone build logic/helpers
+ifeq ($(STANDALONE_BUILD),1)
+
+override_dh_auto_build:
+	make linuxstandalone
+
+override_dh_auto_install:
+	: # nothing to do, we just need to copy the beast, as instructed in debian/install
+
+override_dh_fixperms:
+	dh_fixperms -Xld-linux
+
+endif
+
+prep-standalone:
+	debian/rules undo-standalone
+	QUILT_PATCHES=debian/patches QUILT_SERIES=series.standalone-build quilt push -a
+	debian/create-standalone-changelog
+
+undo-standalone:
 	test -e .git
 	git checkout debian/changelog
 	quilt pop -a || true
-	QUILT_PATCHES=debian/patches QUILT_SERIES=series.standalone-build quilt push -a
-	debian/create-standalone-changelog
-	dpkg-buildpackage -rfakeroot
-	quilt pop -a
+
+dpkg-buildpackage%: prep-standalone
+	umask 022; dpkg-buildpackage -rfakeroot $*
+	debian/rules undo-standalone
+


### PR DESCRIPTION
Standalone was not installable on squeeze because of the git version.  Since per se externals git version doesn't matter beyond original clone (if I got it correctly) and all other tools are also shipped alone, in the first commit I just pruned all of those depends.  
In the 2nd commit I have avoided patching of debian/rules altogether to get proper version for snapshots and just make it more reliable.  The only problem with current '%'-powered setup is that upon finishing necessary action it still runs the main '%' rule:

```
$> debian/rules build-standalone-dsc SNAPSHOT_BUILD=1
...
make[1]: Leaving directory '/home/yoh/proj/git-annex'
dh build-standalone-dsc
dh: Unknown sequence build-standalone-dsc (choose from: binary binary-arch binary-indep build build-arch build-indep clean install install-arch install-indep)
debian/rules:15: recipe for target 'build-standalone-dsc' failed
make: *** [build-standalone-dsc] Error 25
```

any idea @joeyh either it is preventable?