### PR TITLE
Changelog typo: remove, not remote

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -55,7 +55,7 @@ git-annex (5.20151019) unstable; urgency=medium
     and stop recommending bittornado | bittorrent.
   * Debian: Remove build dependency on transformers library, as it is now
     included in ghc.
-  * Debian: Remote menu file, since a desktop file is provided and
+  * Debian: Remove menu file, since a desktop file is provided and
     lintian says there can be only one.
 
  -- Joey Hess <id@joeyh.name>  Mon, 19 Oct 2015 13:59:01 -0400

--- a/doc/news/version_5.20151019.mdwn
+++ b/doc/news/version_5.20151019.mdwn
@@ -49,5 +49,5 @@ git-annex 5.20151019 released with [[!toggle text="these changes"]]
      and stop recommending bittornado | bittorrent.
    * Debian: Remove build dependency on transformers library, as it is now
      included in ghc.
-   * Debian: Remote menu file, since a desktop file is provided and
+   * Debian: Remove menu file, since a desktop file is provided and
      lintian says there can be only one."""]]


### PR DESCRIPTION
This typo can cause confusion.