### PR TITLE
Fixed bug where webapp allows deletion for an unsynced repo

### DIFF
--- a/templates/repolist.hamlet
+++ b/templates/repolist.hamlet
@@ -60,6 +60,11 @@
                       <a href="@{SyncNowRepositoryR $ asUUID repoid}">
                         <span .glyphicon .glyphicon-refresh>
                         \ Sync now
+                    $if notSyncing actions
+                      <a title="Not allowed when syncing is disabled." href="#" style="color: #999;">
+                        <span .glyphicon .glyphicon-trash>
+                        \ Delete
+                    $else
                       <a href="@{DeleteRepositoryR $ asUUID repoid}">
                         <span .glyphicon .glyphicon-trash>
                         \ Delete


### PR DESCRIPTION
Bug is here: https://git-annex.branchable.com/bugs/webapp_should_notice_when_remote_deletion_cannot_complete_due_to_not_syncing/

My fix has been tested, it greys out and disables the Delete button on the dropdown menu for a repo in the webapp when that repo is not synced.