### PR TITLE
cabal constraints for aws and esqueleto

### DIFF
--- a/git-annex.cabal
+++ b/git-annex.cabal
@@ -334,9 +334,9 @@ Executable git-annex
    utf8-string, bytestring, text, sandi, json,
    monad-control, transformers,
    bloomfilter, edit-distance,
-   resourcet, http-conduit, http-client, http-types,
+   resourcet, http-conduit (<2.2.0), http-client, http-types,
    time, old-locale,
-   esqueleto, persistent-sqlite, persistent, persistent-template,
+   esqueleto, persistent-sqlite, persistent (<2.5), persistent-template,
    aeson,
    feed,
    regex-tdfa


### PR DESCRIPTION
aws 0.14.0 is incompatible with http-conduit 2.2.0
https://github.com/aristidb/aws/issues/206

esqueleto 2.4.3 is incompatible with persistent 2.5
https://github.com/prowdsponsor/esqueleto/issues/137
https://github.com/prowdsponsor/esqueleto/pull/141
https://github.com/prowdsponsor/esqueleto/pull/139

Solver needs these hints when building git-annex with +S3 and +Webapp.